### PR TITLE
Allow _id

### DIFF
--- a/config/stylistic-issues.js
+++ b/config/stylistic-issues.js
@@ -71,7 +71,9 @@ module.exports = {
   'no-tabs': 'error',
 
   // disallow dangling underscores in identifiers
-  'no-underscore-dangle': 'error',
+  'no-underscore-dangle': ['error', {
+    allow: ['_id']
+  }],
 
   // disallow whitespace before properties
   'no-whitespace-before-property': 'error',


### PR DESCRIPTION
## レビュー
- [ ] @1000ch 
- [ ] @MatchingAgent/server 

## 内容
- 変数名が `_id` のときのみアンダースコアから始められるように
    - サーバーから返ってくる JSON のキーが `_id` のものがあるため