### PR TITLE
Add ignoreJSX option to no-extra-parens

### DIFF
--- a/config/possible-errors.js
+++ b/config/possible-errors.js
@@ -27,7 +27,8 @@ module.exports = {
 
   // disallow unnecessary parentheses
   'no-extra-parens': ['error', 'all', {
-    nestedBinaryExpressions: false
+    nestedBinaryExpressions: false,
+    ignoreJSX: 'multi-line'
   }],
 
   // disallow unnecessary semicolons


### PR DESCRIPTION
http://eslint.org/docs/rules/no-extra-parens

[react/jsx-wrap-multilines](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-wrap-multilines.md)とのコンフリクトにより、複数行のJSXがカッコの有無に関わらずエラーになる問題を修正