### PR TITLE
fix comma dangle rule

### DIFF
--- a/config/stylistic-issues.js
+++ b/config/stylistic-issues.js
@@ -11,7 +11,7 @@ module.exports = {
   'brace-style': 'error',
 
   // require or disallow trailing commas
-  'comma-dangle': 'error',
+  'comma-dangle': ['error', 'only-multiline'],
 
   // enforce consistent spacing before and after commas
   'comma-spacing': ['error', {


### PR DESCRIPTION
https://github.com/MatchingAgent/tapple-node/blob/master/.github/CODING_RULES.md#%E3%82%AA%E3%83%96%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%AE%E6%9C%80%E5%BE%8C%E3%81%AE%E3%82%AB%E3%83%B3%E3%83%9E
↑このルールに合わせて修正した